### PR TITLE
feat(coredata): integrate Core Data for workout persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+# dir for chatgpt recipes
+.chatgpt

--- a/workoutapp/WorkoutModel.xcdatamodeld/WorkoutModel.xcdatamodel/contents
+++ b/workoutapp/WorkoutModel.xcdatamodeld/WorkoutModel.xcdatamodel/contents
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="ExerciseEntity" representedClassName="ExerciseEntity" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="notes" attributeType="String"/>
+        <attribute name="reps" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sets" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" attributeType="String"/>
+        <relationship name="exerciseGroup" maxCount="1" deletionRule="Nullify" destinationEntity="ExerciseGroupEntity" inverseName="exercises" inverseEntity="ExerciseGroupEntity"/>
+    </entity>
+    <entity name="ExerciseGroupEntity" representedClassName="ExerciseGroupEntity" syncable="YES">
+        <attribute name="groupKey" attributeType="String"/>
+        <relationship name="exercises" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ExerciseEntity" inverseName="exerciseGroup" inverseEntity="ExerciseEntity"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WorkoutEntity" inverseName="exerciseGroups" inverseEntity="WorkoutEntity"/>
+    </entity>
+    <entity name="ScheduleEntity" representedClassName="ScheduleEntity" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="workouts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WorkoutEntity" inverseName="schedule" inverseEntity="WorkoutEntity"/>
+    </entity>
+    <entity name="WorkoutEntity" representedClassName="WorkoutEntity" syncable="YES">
+        <attribute name="day" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <relationship name="exerciseGroups" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ExerciseGroupEntity" inverseName="workout" inverseEntity="ExerciseGroupEntity"/>
+        <relationship name="schedule" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ScheduleEntity" inverseName="workouts" inverseEntity="ScheduleEntity"/>
+    </entity>
+</model>

--- a/workoutapp/workoutapp.xcodeproj/project.pbxproj
+++ b/workoutapp/workoutapp.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		367ED7F42DFB1F1000C79CFE /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 367ED7F32DFB1F1000C79CFE /* CoreData.framework */; };
+		367ED7F72DFB1F4900C79CFE /* WorkoutModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 367ED7F52DFB1F4900C79CFE /* WorkoutModel.xcdatamodeld */; };
+		367ED8102DFB259800C79CFE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 367ED7FA2DFB259800C79CFE /* Preview Assets.xcassets */; };
+		367ED8112DFB259800C79CFE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 367ED8022DFB259800C79CFE /* Assets.xcassets */; };
+		367ED8122DFB259800C79CFE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 367ED8052DFB259800C79CFE /* GoogleService-Info.plist */; };
+		367ED8182DFB259800C79CFE /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED8032DFB259800C79CFE /* AuthManager.swift */; };
+		367ED8192DFB259800C79CFE /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED8042DFB259800C79CFE /* Errors.swift */; };
+		367ED81A2DFB259800C79CFE /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED8072DFB259800C79CFE /* Models.swift */; };
+		367ED81C2DFB259800C79CFE /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED8092DFB259800C79CFE /* SignInView.swift */; };
+		367ED81D2DFB259800C79CFE /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED80A2DFB259800C79CFE /* Utilities.swift */; };
+		367ED81E2DFB259800C79CFE /* WorkoutAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED80C2DFB259800C79CFE /* WorkoutAppDelegate.swift */; };
+		367ED81F2DFB259800C79CFE /* WorkoutRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED80D2DFB259800C79CFE /* WorkoutRepository.swift */; };
+		367ED8202DFB259800C79CFE /* WorkoutTrackerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367ED80E2DFB259800C79CFE /* WorkoutTrackerApp.swift */; };
 		369704DD2D5F909B0059511D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 369704DC2D5F909B0059511D /* GoogleSignIn */; };
 		36D2F0A92DEF165400461CB9 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 36D2F0A82DEF165400461CB9 /* FirebaseAuth */; };
 		36D2F0AD2DEF1EA600461CB9 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 36D2F0AC2DEF1EA600461CB9 /* FirebaseCore */; };
@@ -30,28 +43,40 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		367ED7F32DFB1F1000C79CFE /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		367ED7F62DFB1F4900C79CFE /* WorkoutModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = WorkoutModel.xcdatamodel; sourceTree = "<group>"; };
+		367ED7FA2DFB259800C79CFE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		367ED8022DFB259800C79CFE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		367ED8032DFB259800C79CFE /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		367ED8042DFB259800C79CFE /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		367ED8052DFB259800C79CFE /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		367ED8062DFB259800C79CFE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		367ED8072DFB259800C79CFE /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		367ED8092DFB259800C79CFE /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		367ED80A2DFB259800C79CFE /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		367ED80B2DFB259800C79CFE /* workoutapp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = workoutapp.entitlements; sourceTree = "<group>"; };
+		367ED80C2DFB259800C79CFE /* WorkoutAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutAppDelegate.swift; sourceTree = "<group>"; };
+		367ED80D2DFB259800C79CFE /* WorkoutRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRepository.swift; sourceTree = "<group>"; };
+		367ED80E2DFB259800C79CFE /* WorkoutTrackerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutTrackerApp.swift; sourceTree = "<group>"; };
 		369704AC2D5F8DBE0059511D /* workoutapp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = workoutapp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		369704BC2D5F8DBF0059511D /* workoutappTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = workoutappTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		369704C62D5F8DBF0059511D /* workoutappUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = workoutappUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		369704E12D60CCBC0059511D /* Exceptions for "workoutapp" folder in "workoutapp" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Info.plist,
-			);
-			target = 369704AB2D5F8DBE0059511D /* workoutapp */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		369704AE2D5F8DBE0059511D /* workoutapp */ = {
+		367ED8212DFB25B300C79CFE /* Persistence */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				369704E12D60CCBC0059511D /* Exceptions for "workoutapp" folder in "workoutapp" target */,
-			);
-			path = workoutapp;
+			path = Persistence;
+			sourceTree = "<group>";
+		};
+		367ED83A2DFC8E1D00C79CFE /* WorkoutView */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = WorkoutView;
+			sourceTree = "<group>";
+		};
+		367ED83F2DFC8E3500C79CFE /* ScheduleSelector */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ScheduleSelector;
 			sourceTree = "<group>";
 		};
 		369704BF2D5F8DBF0059511D /* workoutappTests */ = {
@@ -72,6 +97,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				369704DD2D5F909B0059511D /* GoogleSignIn in Frameworks */,
+				367ED7F42DFB1F1000C79CFE /* CoreData.framework in Frameworks */,
 				36D2F0AD2DEF1EA600461CB9 /* FirebaseCore in Frameworks */,
 				36D2F0A92DEF165400461CB9 /* FirebaseAuth in Frameworks */,
 			);
@@ -94,12 +120,53 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		367ED7F22DFB1F1000C79CFE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				367ED7F32DFB1F1000C79CFE /* CoreData.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		367ED7FB2DFB259800C79CFE /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				367ED7FA2DFB259800C79CFE /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		367ED80F2DFB259800C79CFE /* workoutapp */ = {
+			isa = PBXGroup;
+			children = (
+				367ED7FB2DFB259800C79CFE /* Preview Content */,
+				367ED83F2DFC8E3500C79CFE /* ScheduleSelector */,
+				367ED83A2DFC8E1D00C79CFE /* WorkoutView */,
+				367ED8022DFB259800C79CFE /* Assets.xcassets */,
+				367ED8032DFB259800C79CFE /* AuthManager.swift */,
+				367ED8042DFB259800C79CFE /* Errors.swift */,
+				367ED8052DFB259800C79CFE /* GoogleService-Info.plist */,
+				367ED8062DFB259800C79CFE /* Info.plist */,
+				367ED8072DFB259800C79CFE /* Models.swift */,
+				367ED8212DFB25B300C79CFE /* Persistence */,
+				367ED8092DFB259800C79CFE /* SignInView.swift */,
+				367ED80A2DFB259800C79CFE /* Utilities.swift */,
+				367ED80B2DFB259800C79CFE /* workoutapp.entitlements */,
+				367ED80C2DFB259800C79CFE /* WorkoutAppDelegate.swift */,
+				367ED80D2DFB259800C79CFE /* WorkoutRepository.swift */,
+				367ED80E2DFB259800C79CFE /* WorkoutTrackerApp.swift */,
+			);
+			path = workoutapp;
+			sourceTree = "<group>";
+		};
 		369704A32D5F8DBE0059511D = {
 			isa = PBXGroup;
 			children = (
-				369704AE2D5F8DBE0059511D /* workoutapp */,
+				367ED7F52DFB1F4900C79CFE /* WorkoutModel.xcdatamodeld */,
+				367ED80F2DFB259800C79CFE /* workoutapp */,
 				369704BF2D5F8DBF0059511D /* workoutappTests */,
 				369704C92D5F8DBF0059511D /* workoutappUITests */,
+				367ED7F22DFB1F1000C79CFE /* Frameworks */,
 				369704AD2D5F8DBE0059511D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -130,7 +197,9 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				369704AE2D5F8DBE0059511D /* workoutapp */,
+				367ED8212DFB25B300C79CFE /* Persistence */,
+				367ED83A2DFC8E1D00C79CFE /* WorkoutView */,
+				367ED83F2DFC8E3500C79CFE /* ScheduleSelector */,
 			);
 			name = workoutapp;
 			packageProductDependencies = (
@@ -241,6 +310,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				367ED8102DFB259800C79CFE /* Preview Assets.xcassets in Resources */,
+				367ED8112DFB259800C79CFE /* Assets.xcassets in Resources */,
+				367ED8122DFB259800C79CFE /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -265,6 +337,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				367ED8182DFB259800C79CFE /* AuthManager.swift in Sources */,
+				367ED8192DFB259800C79CFE /* Errors.swift in Sources */,
+				367ED81A2DFB259800C79CFE /* Models.swift in Sources */,
+				367ED81C2DFB259800C79CFE /* SignInView.swift in Sources */,
+				367ED81D2DFB259800C79CFE /* Utilities.swift in Sources */,
+				367ED81E2DFB259800C79CFE /* WorkoutAppDelegate.swift in Sources */,
+				367ED81F2DFB259800C79CFE /* WorkoutRepository.swift in Sources */,
+				367ED8202DFB259800C79CFE /* WorkoutTrackerApp.swift in Sources */,
+				367ED7F72DFB1F4900C79CFE /* WorkoutModel.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -630,6 +711,19 @@
 			productName = FirebaseCore;
 		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		367ED7F52DFB1F4900C79CFE /* WorkoutModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				367ED7F62DFB1F4900C79CFE /* WorkoutModel.xcdatamodel */,
+			);
+			currentVersion = 367ED7F62DFB1F4900C79CFE /* WorkoutModel.xcdatamodel */;
+			path = WorkoutModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 369704A42D5F8DBE0059511D /* Project object */;
 }

--- a/workoutapp/workoutapp/Errors.swift
+++ b/workoutapp/workoutapp/Errors.swift
@@ -16,9 +16,28 @@ enum NetworkError: Error {
     case decodingFailed(Error)
 }
 
-enum AuthError : Error {
-    case invalidCredentials
-    case expiredToken
-    case missingToken
-    case unknown
+enum AuthError: LocalizedError {
+    case noPresentingViewController
+    case noClientID
+    case noIDToken
+    case notAuthenticated
+    case googleSignInCancelled
+    case unknown(Error)
+    
+    var errorDescription: String? {
+        switch self {
+        case .noPresentingViewController:
+            return "No presenting view controller available"
+        case .noClientID:
+            return "No Google client ID configured"
+        case .noIDToken:
+            return "Failed to get ID token from Google"
+        case .notAuthenticated:
+            return "User is not authenticated"
+        case .googleSignInCancelled:
+            return "Google Sign-In was cancelled"
+        case .unknown(let error):
+            return "Authentication error: \(error.localizedDescription)"
+        }
+    }
 }

--- a/workoutapp/workoutapp/Errors.swift
+++ b/workoutapp/workoutapp/Errors.swift
@@ -41,3 +41,8 @@ enum AuthError: LocalizedError {
         }
     }
 }
+
+enum CoreDataError: Error {
+    case noDataFound
+    case invalidData(String)
+}

--- a/workoutapp/workoutapp/Info.plist
+++ b/workoutapp/workoutapp/Info.plist
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>ServerEnvironments</key>
-	<dict/>
-	<key>dev</key>
-	<string>&quot;http://localhost:3000&quot;</string>
-	<key>prod</key>
-	<string>&quot;https://zwsmith.me&quot;</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>com.googleusercontent.apps.951785297505-leo3cs9atmgrl42or2clttjer184hl4f</string>
-			</array>
-		</dict>
-	</array>
-</dict>
+	<dict>
+		<key>CFBundleURLTypes</key>
+		<array>
+			<dict>
+				<key>CFBundleTypeRole</key>
+				<string>Editor</string>
+				<key>CFBundleURLSchemes</key>
+				<array>
+					<string>com.googleusercontent.apps.951785297505-1372hd2q00o9neqnfc4rrj9m6d5gdrte</string>
+				</array>
+			</dict>
+		</array>
+		<key>ServerEnvironments</key>
+		<dict />
+		<key>dev</key>
+		<string>&quot;http://localhost:3000&quot;</string>
+		<key>prod</key>
+		<string>&quot;https://zwsmith.me&quot;</string>
+	</dict>
 </plist>

--- a/workoutapp/workoutapp/Models.swift
+++ b/workoutapp/workoutapp/Models.swift
@@ -8,19 +8,37 @@
 import Foundation
 
 struct Schedule: Codable, Equatable {
+    
     let name: String
-    let workouts: [String: WorkoutDay]
+    let workouts: [Workout]
+    init(name: String, workouts: [Workout]) {
+        self.name = name
+        self.workouts = workouts
+    }
 }
 
-struct WorkoutDay: Codable, Equatable {
+struct Workout: Codable, Equatable {
     let day: String
     let exercises: [String: [Exercise]]
+    init(day: String, exercises: [String : [Exercise]]) {
+        self.day = day
+        self.exercises = exercises
+    }
 }
 
 struct Exercise: Codable, Equatable {
+    
     let name: String
     let sets: Int
     let reps: Int
     let weight: String
     let notes: String
+    init(name: String, sets: Int, reps: Int, weight: String, notes: String, id: String? = nil) {
+        
+        self.name = name
+        self.sets = sets
+        self.reps = reps
+        self.weight = weight
+        self.notes = notes
+    }
 }

--- a/workoutapp/workoutapp/Persistence/Entities/ExerciseEntity+CoreDataClass.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/ExerciseEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ExerciseEntity+CoreDataClass.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ExerciseEntity)
+public class ExerciseEntity: NSManagedObject {
+
+}

--- a/workoutapp/workoutapp/Persistence/Entities/ExerciseEntity+CoreDataProperties.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/ExerciseEntity+CoreDataProperties.swift
@@ -1,0 +1,42 @@
+//
+//  ExerciseEntity+CoreDataProperties.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ExerciseEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ExerciseEntity> {
+        return NSFetchRequest<ExerciseEntity>(entityName: "ExerciseEntity")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var sets: Int64
+    @NSManaged public var reps: Int64
+    @NSManaged public var weight: String?
+    @NSManaged public var notes: String?
+    @NSManaged public var exerciseGroup: ExerciseGroupEntity?
+
+}
+
+extension ExerciseEntity : Identifiable {
+
+}
+
+extension ExerciseEntity {
+    func toExercise() -> Exercise {
+        return Exercise(
+            name: self.name ?? "",
+            sets: Int(self.sets),
+            reps: Int(self.reps),
+            weight: self.weight ?? "",
+            notes: self.notes ?? ""
+        )
+    }
+}

--- a/workoutapp/workoutapp/Persistence/Entities/ExerciseGroupEntity+CoreDataClass.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/ExerciseGroupEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ExerciseGroupEntity+CoreDataClass.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ExerciseGroupEntity)
+public class ExerciseGroupEntity: NSManagedObject {
+
+}

--- a/workoutapp/workoutapp/Persistence/Entities/ExerciseGroupEntity+CoreDataProperties.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/ExerciseGroupEntity+CoreDataProperties.swift
@@ -1,0 +1,64 @@
+//
+//  ExerciseGroupEntity+CoreDataProperties.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ExerciseGroupEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ExerciseGroupEntity> {
+        return NSFetchRequest<ExerciseGroupEntity>(entityName: "ExerciseGroupEntity")
+    }
+
+    @NSManaged public var groupKey: String?
+    @NSManaged public var workout: WorkoutEntity?
+    @NSManaged public var exercises: NSSet?
+
+}
+
+// MARK: Generated accessors for exercises
+extension ExerciseGroupEntity {
+
+    @objc(addExercisesObject:)
+    @NSManaged public func addToExercises(_ value: ExerciseEntity)
+
+    @objc(removeExercisesObject:)
+    @NSManaged public func removeFromExercises(_ value: ExerciseEntity)
+
+    @objc(addExercises:)
+    @NSManaged public func addToExercises(_ values: NSSet)
+
+    @objc(removeExercises:)
+    @NSManaged public func removeFromExercises(_ values: NSSet)
+
+}
+
+extension ExerciseGroupEntity : Identifiable {
+
+}
+
+extension ExerciseGroupEntity {
+    func toExerciseGroup() throws -> (String, [Exercise]) {
+        guard let groupKey = self.groupKey else {
+            throw CoreDataError.invalidData("Exercise group key is missing")
+        }
+        
+        var exerciseList: [Exercise] = []
+        
+        // Convert ExerciseEntity to Exercise
+        if let exerciseEntities = self.exercises?.allObjects as? [ExerciseEntity] {
+            for exerciseEntity in exerciseEntities {
+                let exercise = exerciseEntity.toExercise()
+                exerciseList.append(exercise)
+            }
+        }
+        
+        return (groupKey, exerciseList)
+    }
+}

--- a/workoutapp/workoutapp/Persistence/Entities/ScheduleEntity+CoreDataClass.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/ScheduleEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ScheduleEntity+CoreDataClass.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ScheduleEntity)
+public class ScheduleEntity: NSManagedObject {
+
+}

--- a/workoutapp/workoutapp/Persistence/Entities/ScheduleEntity+CoreDataProperties.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/ScheduleEntity+CoreDataProperties.swift
@@ -1,0 +1,66 @@
+//
+//  ScheduleEntity+CoreDataProperties.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ScheduleEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ScheduleEntity> {
+        return NSFetchRequest<ScheduleEntity>(entityName: "ScheduleEntity")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var id: String?
+    @NSManaged public var workouts: NSSet?
+
+}
+
+// MARK: Generated accessors for workouts
+extension ScheduleEntity {
+
+    @objc(addWorkoutsObject:)
+    @NSManaged public func addToWorkouts(_ value: WorkoutEntity)
+
+    @objc(removeWorkoutsObject:)
+    @NSManaged public func removeFromWorkouts(_ value: WorkoutEntity)
+
+    @objc(addWorkouts:)
+    @NSManaged public func addToWorkouts(_ values: NSSet)
+
+    @objc(removeWorkouts:)
+    @NSManaged public func removeFromWorkouts(_ values: NSSet)
+
+}
+
+extension ScheduleEntity : Identifiable {
+
+}
+
+extension ScheduleEntity {
+    func toSchedule() throws -> Schedule {
+        guard let name = self.name else {
+            throw CoreDataError.invalidData("Schedule name is missing")
+        }
+        
+        var workouts: [Workout] = []
+        
+        // Convert WorkoutEntity to Workout
+        if let workoutEntities = self.workouts?.allObjects as? [WorkoutEntity] {
+            for workoutEntity in workoutEntities {
+                let workout = try workoutEntity.toWorkout()
+                workouts.append(workout)
+            }
+        }
+        
+        return Schedule(name: name, workouts: workouts)
+    }
+}
+
+

--- a/workoutapp/workoutapp/Persistence/Entities/WorkoutEntity+CoreDataClass.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/WorkoutEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  WorkoutEntity+CoreDataClass.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(WorkoutEntity)
+public class WorkoutEntity: NSManagedObject {
+
+}

--- a/workoutapp/workoutapp/Persistence/Entities/WorkoutEntity+CoreDataProperties.swift
+++ b/workoutapp/workoutapp/Persistence/Entities/WorkoutEntity+CoreDataProperties.swift
@@ -1,0 +1,66 @@
+//
+//  WorkoutEntity+CoreDataProperties.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension WorkoutEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WorkoutEntity> {
+        return NSFetchRequest<WorkoutEntity>(entityName: "WorkoutEntity")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var day: String?
+    @NSManaged public var schedule: ScheduleEntity?
+    @NSManaged public var exerciseGroups: NSSet?
+
+}
+
+// MARK: Generated accessors for exerciseGroups
+extension WorkoutEntity {
+
+    @objc(addExerciseGroupsObject:)
+    @NSManaged public func addToExerciseGroups(_ value: ExerciseGroupEntity)
+
+    @objc(removeExerciseGroupsObject:)
+    @NSManaged public func removeFromExerciseGroups(_ value: ExerciseGroupEntity)
+
+    @objc(addExerciseGroups:)
+    @NSManaged public func addToExerciseGroups(_ values: NSSet)
+
+    @objc(removeExerciseGroups:)
+    @NSManaged public func removeFromExerciseGroups(_ values: NSSet)
+
+}
+
+extension WorkoutEntity : Identifiable {
+
+}
+
+extension WorkoutEntity {
+    func toWorkout() throws -> Workout {
+        guard let day = self.day else {
+            throw CoreDataError.invalidData("Workout day is missing")
+        }
+        
+        var exercises: [String: [Exercise]] = [:]
+        
+        // Convert ExerciseGroupEntity to grouped exercises
+        if let groupEntities = self.exerciseGroups?.allObjects as? [ExerciseGroupEntity] {
+            for groupEntity in groupEntities {
+                let (groupKey, exerciseList) = try groupEntity.toExerciseGroup()
+                exercises[groupKey] = exerciseList
+            }
+        }
+        
+        return Workout(day: day, exercises: exercises)
+    }
+}
+

--- a/workoutapp/workoutapp/Persistence/PersistenceController.swift
+++ b/workoutapp/workoutapp/Persistence/PersistenceController.swift
@@ -1,0 +1,37 @@
+//
+//  PersistenceController.swift
+//  workoutapp
+//
+//  Created by Zach Smith on 6/12/25.
+//
+
+import CoreData
+import Foundation
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    var context: NSManagedObjectContext {
+        container.viewContext
+    }
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "WorkoutModel")
+
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(
+                fileURLWithPath: "/dev/null"
+            )
+        }
+
+        container.loadPersistentStores { storeDescription, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+}

--- a/workoutapp/workoutapp/SignInView.swift
+++ b/workoutapp/workoutapp/SignInView.swift
@@ -9,12 +9,9 @@ import SwiftUI
 import FirebaseAuth
 
 struct SignInView: View {
-    @State private var email: String = ""
-    @State private var password: String = ""
-    @State private var isSigningIn = false
+    let auth: any AuthManager = AuthManagerImpl.shared
     @State private var signInError: String? = nil
-    
-    let auth = AuthManagerImpl.shared
+    @State private var isSigningIn = false
 
     var body: some View {
         VStack(spacing: 20) {
@@ -26,20 +23,6 @@ struct SignInView: View {
                 .font(.largeTitle)
                 .bold()
 
-            TextField("Email", text: $email)
-                .keyboardType(.emailAddress)
-                .textContentType(.emailAddress)
-                .autocapitalization(.none)
-                .padding()
-                .background(Color(UIColor.secondarySystemBackground))
-                .cornerRadius(8)
-
-            SecureField("Password", text: $password)
-                .textContentType(.password)
-                .padding()
-                .background(Color(UIColor.secondarySystemBackground))
-                .cornerRadius(8)
-
             if let error = signInError {
                 Text(error)
                     .foregroundColor(.red)
@@ -50,39 +33,13 @@ struct SignInView: View {
                 ProgressView("Signing in...")
                     .padding(.top, 20)
             }
-            Button(
-                action: {
-                    Task {
-                        signInError = nil
-                        isSigningIn = true
-                        do {
-                            try await auth.signInWithEmailAndPassword(email: "zach.smith33@gmail.com", password: "password")
-                        } catch {
-                            signInError = error.localizedDescription
-                        }
-                        isSigningIn = false
-                    }
-                }
-            ) {
-                HStack {
-                    Image(systemName: "person.fill.checkmark")
-                    Text("Sign In")
-                }
-                .padding()
-                .background(Color.blue)
-                .foregroundColor(.white)
-                .cornerRadius(8)
-            }
-            .padding(.top, 20)
-                
+
             Button(action: {
                 Task {
                     signInError = nil
                     isSigningIn = true
                     do {
-                        try await auth
-                            .createUser(email: email, password: password)
-                        // handle post-account-creation logic if needed
+                        try await auth.signInWithGoogle()
                     } catch {
                         signInError = error.localizedDescription
                     }
@@ -90,19 +47,15 @@ struct SignInView: View {
                 }
             }) {
                 HStack {
-                    Image(systemName: "person.badge.plus")
-                    Text("Create Account")
+                    Image(systemName: "globe")
+                    Text("Sign In with Google")
                 }
                 .padding()
-                .background(Color.green)
+                .background(Color.blue)
                 .foregroundColor(.white)
                 .cornerRadius(8)
             }
-            .disabled(email.isEmpty || password.isEmpty)
-            .padding(.top, 10)
-            
         }
         .padding()
     }
 }
-

--- a/workoutapp/workoutapp/WorkoutAppDelegate.swift
+++ b/workoutapp/workoutapp/WorkoutAppDelegate.swift
@@ -9,13 +9,22 @@ import Foundation
 import SwiftUI
 import FirebaseCore
 import FirebaseAuth
+import GoogleSignIn
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    
-    FirebaseApp.configure()
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
 
-    return true
-  }
+        FirebaseApp.configure()
+        AuthManagerImpl.shared.listenForAuthStateChanges()
+
+        return true
+    }
+    
+    func application(_ app: UIApplication,
+                     open url: URL,
+                     options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        return GIDSignIn.sharedInstance.handle(url)
+    }
+    
 }

--- a/workoutapp/workoutapp/WorkoutTrackerApp.swift
+++ b/workoutapp/workoutapp/WorkoutTrackerApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import GoogleSignIn
 import FirebaseCore
+import CoreData
 
 // MARK: - App Entry Point
 
@@ -9,6 +10,7 @@ struct WorkoutTrackerApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     @StateObject var authManager = AuthManagerImpl.shared
+    let persistenceController = PersistenceController.shared
     
     let repository: WorkoutRepository
     

--- a/workoutapp/workoutapp/WorkoutTrackerApp.swift
+++ b/workoutapp/workoutapp/WorkoutTrackerApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import GoogleSignIn
+import FirebaseCore
 
 // MARK: - App Entry Point
 

--- a/workoutapp/workoutapp/WorkoutView/WorkoutView.swift
+++ b/workoutapp/workoutapp/WorkoutView/WorkoutView.swift
@@ -25,10 +25,10 @@ struct WorkoutView: View {
                 errorView(string)
             case .data(let workoutGroup):
                     VStack {
-                        dayPicker(days:  Array(workoutGroup.workouts.keys).sorted())
+                        dayPicker(days: workoutGroup.workouts.map(\.day))
                         if let selected = selectedDay,
-                           let workoutDayResponse = workoutGroup.workouts[selected] {
-                            ExerciseListView(exercises: workoutDayResponse.exercises)
+                           let workoutDay = workoutGroup.workouts.first(where: { $0.day == selected }) {
+                            ExerciseListView(exercises: workoutDay.exercises)
                         } else {
                             Text("Select a workout day")
                                 .foregroundColor(.secondary)
@@ -43,7 +43,7 @@ struct WorkoutView: View {
         .onChange(of: viewModel.state) {
             if case let .data(workoutGroup) = viewModel.state,
                selectedDay == nil {
-                selectedDay = Array(workoutGroup.workouts.keys).sorted().first
+                selectedDay = workoutGroup.workouts.sorted(by: { $0.day < $1.day }).first?.day
             }
         }
         .padding()

--- a/workoutapp/workoutapp/WorkoutView/WorkoutViewModel.swift
+++ b/workoutapp/workoutapp/WorkoutView/WorkoutViewModel.swift
@@ -24,8 +24,7 @@ class WorkoutViewModel: ObservableObject {
     func getWorkouts() async {
         state = .loading
         do {
-            let workouts = try await repository.fetchSchedule(for: selectedWeek)
-            print(workouts)
+            let workouts = try await repository.getSchedule(for: selectedWeek)
             state = .data(workouts)
         } catch {
             state = .error(error.localizedDescription)


### PR DESCRIPTION
- Added Core Data model `WorkoutModel.xcdatamodeld` with entities:
  ScheduleEntity, WorkoutEntity, ExerciseGroupEntity, ExerciseEntity
- Implemented Core Data classes and properties for each entity
- Created `PersistenceController` to manage Core Data stack
- Updated `WorkoutRepositoryImpl` to:
  - Fetch schedules from local storage if available
  - Save remote schedules into Core Data
- Refactored `Workout` model to match Core Data schema
- Adjusted WorkoutView to handle updated structure
- Modified `.gitignore` to exclude `.chatgpt` directory
- Registered CoreData.framework and data model in project settings